### PR TITLE
Harden Gitea GitHub synchronization

### DIFF
--- a/.gitea/workflows/main.yml
+++ b/.gitea/workflows/main.yml
@@ -188,7 +188,6 @@ jobs:
     needs: build-and-test
     if: ${{ needs.build-and-test.result == 'success' }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -201,80 +200,56 @@ jobs:
           git config --global init.defaultBranch dev
       
       - name: Configure GitHub Remote
+        id: github-sync
+        env:
+          GITHUB_SYNC_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if GitHub token is available
-          if [[ -z "${{ secrets.GITHUB_TOKEN }}" ]]; then
-            echo "❌ GITHUB_TOKEN secret is not set!"
-            echo "⚠️ Skipping GitHub sync due to missing token"
+          if [[ -z "$GITHUB_SYNC_TOKEN" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub sync skipped: credential is not configured"
             exit 0
           fi
-          
-          # Remove existing remote if it exists
+
           git remote remove github 2>/dev/null || true
-          
-          # Add GitHub remote with token authentication
-          git remote add github https://${{ secrets.GITHUB_TOKEN }}@github.com/discours/discoursio-webapp.git
-          
-          # Test remote connection
-          echo "Testing GitHub remote connection..."
-          if git ls-remote github HEAD; then
-            echo "✅ Successfully connected to GitHub remote"
-                    else
-            echo "❌ Failed to connect to GitHub remote"
-            echo "Checking token permissions..."
-            curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                -H "Accept: application/vnd.github.v3+json" \
-                https://api.github.com/repos/discours/discoursio-webapp || true
-            echo "⚠️ Skipping GitHub sync due to connection issues"
-            exit 0
-          fi
-          
-          # Fetch all branches and tags from GitHub
-          echo "Fetching from GitHub..."
-          git fetch github
-      
+          git remote add github https://github.com/discours/discoursio-webapp.git
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
       - name: Sync Current Branch
+        if: steps.github-sync.outputs.enabled == 'true'
+        env:
+          GITHUB_SYNC_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get current branch name
           CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
           echo "Current branch: $CURRENT_BRANCH"
-          
-          # Skip main and dev branches
-          if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "dev" ]]; then
-            echo "⏭️ Skipping sync for protected branch: $CURRENT_BRANCH"
-            exit 0
-          fi
-          
-          # Debug information
-          echo "=== Debug Info ==="
-          echo "Git status:"
-          git status --porcelain
-          echo "Current HEAD:"
-          git log --oneline -1
-          echo "Remote info:"
-          git remote -v
-          
-          # Push only feature/* and hotfix/* branches that passed CI
-          echo "=== Syncing branch: $CURRENT_BRANCH ==="
-          
-          # Try force-with-lease first
-          if git push github $CURRENT_BRANCH:$CURRENT_BRANCH --force-with-lease; then
-            echo "✅ Successfully synced with --force-with-lease"
-          else
-            echo "⚠️ Force-with-lease failed, trying regular force push..."
-            if git push github $CURRENT_BRANCH:$CURRENT_BRANCH --force; then
-              echo "✅ Successfully synced with --force"
-            else
-              echo "❌ Both push attempts failed!"
-              echo "=== Git push error details ==="
-              git push github $CURRENT_BRANCH:$CURRENT_BRANCH --force -v 2>&1 || true
-              echo "⚠️ GitHub sync failed, but continuing workflow"
+
+          case "$CURRENT_BRANCH" in
+            main|dev)
+              echo "Skipping GitHub sync for protected branch: $CURRENT_BRANCH"
               exit 0
-            fi
-          fi
-      
-      - name: Verify Sync
-        run: |
-          echo "=== GitHub Remote Branches ==="
-          git ls-remote --heads github
+              ;;
+            feature/*|hotfix/*)
+              ;;
+            *)
+              echo "Refusing to sync unsupported branch: $CURRENT_BRANCH"
+              exit 1
+              ;;
+          esac
+
+          askpass_dir=$(mktemp -d)
+          trap 'rm -rf "$askpass_dir"' EXIT
+          askpass_path="$askpass_dir/git-askpass"
+          printf '%s\n' \
+            '#!/usr/bin/env bash' \
+            'case "$1" in' \
+            '  *Username*) printf "%s\n" "x-access-token" ;;' \
+            '  *Password*) printf "%s\n" "$GITHUB_SYNC_TOKEN" ;;' \
+            '  *) exit 1 ;;' \
+            'esac' > "$askpass_path"
+          chmod 700 "$askpass_path"
+          export GIT_ASKPASS="$askpass_path"
+          export GIT_TERMINAL_PROMPT=0
+
+          git push github "${CURRENT_BRANCH}:${CURRENT_BRANCH}"
+          git ls-remote --exit-code --heads github "$CURRENT_BRANCH" >/dev/null
+          echo "GitHub sync verified for $CURRENT_BRANCH"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Reject encoded and plain path traversal in the custom static-file server.
 - Remove OAuth/session payload logging and bearer-token previews from upload runtime diagnostics, including the public debug route.
 - Stop returning mail-provider responses and errors to public clients.
+- Keep GitHub sync credentials out of remote URLs and diagnostic output, and reject history-rewriting sync pushes.
 
 ## [0.15.5]
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "e2e:ci": "cross-env CI=true npm run e2e:test",
     "e2e:install": "playwright install chromium",
     "test": "npm run test:unit",
-    "test:unit": "node --test tests/unit/static-files.test.mjs tests/unit/request-validation.test.mjs tests/unit/demo-api.test.mjs tests/unit/image-runtime.test.mjs tests/unit/runtime-auth-logging.test.mjs",
+    "test:unit": "node --test tests/unit/static-files.test.mjs tests/unit/request-validation.test.mjs tests/unit/demo-api.test.mjs tests/unit/image-runtime.test.mjs tests/unit/runtime-auth-logging.test.mjs tests/unit/gitea-workflow-security.test.mjs",
     "build:ci": "cross-env SASS_FORCE_JS=true npm run build",
     "templates": "node ./templates/compile.cjs",
     "setup:https": "node scripts/setup-https.mjs",

--- a/tests/unit/gitea-workflow-security.test.mjs
+++ b/tests/unit/gitea-workflow-security.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const workflowUrl = new URL('../../.gitea/workflows/main.yml', import.meta.url)
+const workflow = await readFile(workflowUrl, 'utf8')
+
+test('GitHub sync keeps credentials out of URLs and diagnostics', () => {
+  assert.doesNotMatch(workflow, /https:\/\/\$\{\{\s*secrets\./)
+  assert.doesNotMatch(workflow, /git remote -v/)
+  assert.doesNotMatch(workflow, /curl[^\n]+Authorization/)
+  assert.match(workflow, /GIT_ASKPASS/)
+  assert.match(
+    workflow,
+    /git remote add github https:\/\/github\.com\/discours\/discoursio-webapp\.git/,
+  )
+})
+
+test('GitHub sync rejects unsupported branches and history rewrites', () => {
+  assert.match(workflow, /feature\/\*\|hotfix\/\*/)
+  assert.match(workflow, /Refusing to sync unsupported branch/)
+  assert.doesNotMatch(workflow, /--force(?:-with-lease)?/)
+  assert.match(
+    workflow,
+    /git push github "\$\{CURRENT_BRANCH\}:\$\{CURRENT_BRANCH\}"/,
+  )
+})


### PR DESCRIPTION
## Summary

- keep the GitHub sync credential out of Git remote URLs and diagnostic output
- restrict synchronization to `feature/*` and `hotfix/*` and remove history-rewriting push fallbacks
- surface sync failures instead of hiding them behind `continue-on-error`
- add a static regression test to `test:unit`

## Validation

- `npm run check` — passed (13 unit tests)
- `npm run build` — passed
- workflow YAML parse — passed

## Operational boundary

This change does not deploy anything and does not read or expose credential values. The actual Gitea runner and mirror path were not exercised from this checkout, so live synchronization remains **UNVERIFIABLE** pending maintainer review.