### PR TITLE
Align npm command documentation with package scripts

### DIFF
--- a/docs/development/npm-scripts.md
+++ b/docs/development/npm-scripts.md
@@ -1,118 +1,120 @@
-# NPM Scripts Документация
+# npm scripts
 
-## 🚀 Основные команды разработки
+`package.json` is the source of truth for commands. This page explains the scripts that contributors are expected to use and calls out commands that need external services or modify the local checkout.
 
-### **Запуск и сборка**
+The repository requires Node.js 20.19+ and npm 10+. Use the committed npm lockfile:
+
 ```bash
-npm run dev          # Запуск dev сервера с HMR
-npm run build        # Production сборка
-npm start            # Запуск production сервера
-npm run start:debug  # Запуск с отладчиком Node.js
+npm ci
 ```
 
-## 🔍 Проверка кода
+Normal installation has no project lifecycle script that downloads browsers, runs GraphQL code generation, installs certificates, or patches dependencies.
 
-### **Линтинг и форматирование (Biome)**
+## First run
+
+| Command | Purpose | Requirements |
+| --- | --- | --- |
+| `npm run dev:demo` | Start the app against a deterministic, loopback-only, read-only fixture | No account or external service |
+| `npm run dev` | Start the Vinxi development server against configured endpoints | Compatible services configured in `.env` |
+| `npm run setup:https` | Create local development certificates | Optional `mkcert`; explicitly changes the local trust setup |
+
+Use `npm run dev:demo` for the first checkout. The fixture covers the application shell and deterministic public states, not authenticated or write flows.
+
+## Quality gates
+
+| Command | Purpose | Changes files |
+| --- | --- | --- |
+| `npm run check` | Run lint, TypeScript, and the deterministic unit suite | No |
+| `npm run lint` | Run Biome lint checks | No |
+| `npm run typecheck` | Run TypeScript without emitting files | No |
+| `npm test` | Run the unit suite through `test:unit` | No |
+| `npm run test:unit` | Run the explicit Node test files used by CI | No |
+| `npm run fix` | Apply Biome lint and formatting fixes | Yes |
+| `npm run format` | Apply Biome formatting | Yes |
+
+Review every change produced by `fix` or `format`; neither command is a substitute for `npm run check`.
+
+## GraphQL code generation
+
+| Command | Purpose |
+| --- | --- |
+| `npm run codegen:check` | Regenerate both clients and fail if committed output drifts |
+| `npm run codegen:all` | Regenerate the core and inbox clients |
+| `npm run codegen` | Regenerate the core client |
+| `npm run codegen:inbox` | Regenerate the inbox client |
+
+Code generation uses the compatibility schemas committed under `src/graphql/schema/`. It is reproducible offline, but it does not prove that a live backend currently exposes the same contract.
+
+## Build and local production server
+
+| Command | Purpose | Notes |
+| --- | --- | --- |
+| `npm run build` | Create the production SSR build | Main build gate used by CI |
+| `npm run build:ci` | Build with CI-compatible Sass settings | Convenience wrapper |
+| `npm run build:netlify` | Run both code generators, then build | Builds locally; does not deploy |
+| `npm run build:debug` | Build with debug configuration enabled | Diagnostic use only |
+| `npm start` | Build through `prestart`, then start the custom production server | Local process; no deployment |
+| `npm run start:debug` | Build and start with debug configuration | Diagnostic use only |
+
+`npm start` always invokes `npm run build` first. Use it only when that extra build is intended.
+
+## Playwright
+
+### Deterministic demo
+
 ```bash
-npm run lint         # Проверка кода без исправлений
-npm run lint:fix     # Проверка и автоматическое исправление ошибок  
-npm run format       # Форматирование всего кода
-npm run fix          # Полное исправление: lint + format
+npm run e2e:install
+npm run e2e:demo
 ```
 
-### **Проверка типов (TypeScript)**
+`e2e:install` downloads the optional Chromium binary. `e2e:demo` runs against the synthetic local fixture and needs no account credentials.
+
+### Service-dependent suites
+
+The following commands require compatible configured services, and some require a dedicated test account. They are not equivalent to the deterministic CI demo:
+
+- `npm run e2e`
+- `npm run e2e:test`
+- `npm run e2e:smoke`
+- `npm run e2e:auth`
+- `npm run e2e:ci`
+- `npm run e2e:hydration`
+- `npm run dev:e2e`
+- `npm run test:editor-auth`
+- `npm run test:editor-format`
+- `npm run test:editor-upload`
+- `npm run test:editor-workflow`
+- `npm run test:editor-all`
+
+Never use personal or production credentials for these suites.
+
+### Interactive and diagnostic Playwright commands
+
+- `npm run e2e:ui`
+- `npm run e2e:ui:smoke`
+- `npm run e2e:ui:auth`
+- `npm run e2e:debug`
+- `npm run e2e:report`
+
+These commands may open a browser or report UI. Authentication requirements still apply to the corresponding scenarios.
+
+## Cleanup and maintenance
+
+| Command | Purpose | Effect |
+| --- | --- | --- |
+| `npm run e2e:clean` | Remove Playwright result and report directories | Deletes generated test artifacts |
+| `npm run clean` | Remove Vinxi and output build artifacts | Deletes generated build artifacts |
+| `npm run reset` | Clean, then run `npm install` | Recreates local dependencies; prefer `npm ci` for reproducibility |
+| `npm run templates` | Compile the repository's templates | May update generated template output |
+
+## CI-equivalent local sequence
+
 ```bash
-npm run typecheck    # Проверка TypeScript типов без компиляции
-npm run check        # Полная проверка: lint + typecheck
+npm ci --ignore-scripts
+npm run codegen:check
+npm run check
+npm audit --omit=dev
+npm run build
 ```
 
-## 🧪 Тестирование
-
-### **E2E тесты (Playwright)**
-```bash
-npm run e2e:install  # Установка Playwright браузеров
-npm run e2e:tests    # Запуск E2E тестов (chromium)
-npm run e2e:tests:ci # Запуск в CI режиме
-npm run e2e          # Полный E2E прогон с окружением
-```
-
-## 🔧 Инструменты
-
-### **GraphQL Codegen**
-```bash
-npm run codegen      # Генерация TypeScript типов из GraphQL схем
-```
-
-### **Шаблоны**
-```bash
-npm run templates    # Компиляция шаблонов
-```
-
-### **Очистка**
-```bash
-npm run clean        # Очистка build директорий
-npm run reset        # Полная очистка + переустановка зависимостей
-```
-
-## 📋 Автоматические хуки
-
-### **PostInstall**
-```bash
-# Выполняется автоматически после npm install
-patch-package        # Применение патчей к зависимостям
-npm run codegen      # Генерация GraphQL типов
-```
-
-### **PreStart**
-```bash
-# Выполняется автоматически перед npm start
-npm run build        # Сборка для production
-```
-
-## 🛠️ Workflow рекомендации
-
-### **Разработка**
-```bash
-# Стандартный цикл разработки
-npm run dev          # Запуск dev сервера
-npm run check        # Проверка перед коммитом
-npm run fix          # Автоматическое исправление
-```
-
-### **CI/CD**
-```bash
-# Последовательность для CI
-npm install          # + автоматически postinstall
-npm run check        # Проверка кода и типов
-npm run e2e:tests:ci # E2E тесты
-npm run build        # Production сборка
-```
-
-### **Очистка проблем**
-```bash
-# При проблемах с зависимостями
-npm run reset        # Полная переустановка
-npm run codegen      # Перегенерация GraphQL типов
-```
-
-## ⚡ Оптимизации
-
-### **Lightning CSS интеграция**
-- CSS трансформация и минификация автоматическая
-- Не требует отдельных команд
-- Встроена в `dev` и `build` процессы
-
-### **Biome заменяет**
-- ✅ ESLint линтинг
-- ✅ Prettier форматирование  
-- ✅ Единая конфигурация
-- ⚡ 10-100x быстрее традиционных инструментов
-
-### **Removed tools**
-- ❌ Stylelint (заменен Lightning CSS)
-- ❌ PostCSS отдельные плагины
-- ❌ Множественные линтеры
-
----
-
-**Итого**: Современный, быстрый toolchain с минимумом зависимостей! 
+The runtime audit is a separate command because the full development dependency graph contains historical tooling findings that are not safely auto-fixable.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,109 +1,51 @@
-# 📋 NPM команды
+# Command reference
 
-## 📋 Оглавление
+This is the short command map for contributors. See [npm scripts](../development/npm-scripts.md) for requirements, side effects, and the complete Playwright classification. `package.json` remains the source of truth.
 
-- [🚀 Разработка](#-разработка)
-- [🔍 Проверка качества](#-проверка-качества)
-- [🧪 Тестирование](#-тестирование)
-- [🛠️ Дополнительные инструменты](#️-дополнительные-инструменты)
-- [🔧 Отладка](#-отладка)
-- [📊 CI/CD команды](#-cicd-команды)
-- [🔄 Рабочий процесс](#-рабочий-процесс)
-- [🎯 Быстрые команды](#-быстрые-команды)
-- [📈 Оптимизации](#-оптимизации)
+## Common workflows
 
-## 🚀 Разработка
+| Goal | Commands | External requirements |
+| --- | --- | --- |
+| First local checkout | `npm ci`, then `npm run dev:demo` | None |
+| Develop against configured services | `npm ci`, then `npm run dev` | Compatible endpoints in `.env` |
+| Verify a normal change | `npm run codegen:check`, `npm run check`, `npm run build` | None |
+| Run deterministic browser smoke | `npm run e2e:install`, then `npm run e2e:demo` | Chromium download; no account |
+| Start the production build locally | `npm start` | Builds first through `prestart` |
 
-| Команда | Описание | Использование |
-|---------|----------|---------------|
-| `npm run dev` | Запуск сервера разработки с HMR | Основная команда разработки |
-| `npm run build` | Сборка для продакшена | Перед деплоем |
-| `npm run preview` | Предпросмотр сборки локально | Проверка production версии |
+## Read-only checks
 
-## 🔍 Проверка качества
+| Command | Checks |
+| --- | --- |
+| `npm run codegen:check` | GraphQL generated-client drift |
+| `npm run check` | Biome, TypeScript, and unit tests |
+| `npm run lint` | Biome lint rules |
+| `npm run typecheck` | TypeScript types |
+| `npm test` | Deterministic Node unit tests |
+| `npm run build` | Production SSR build |
 
-| Команда | Описание | Использование |
-|---------|----------|---------------|
-| `npm run typecheck` | Проверка TypeScript типов | Перед коммитом |
-| `npm run lint` | Линтинг кода Biome | Проверка стиля |
-| `npm run fix` | Автоисправление стиля | Исправление ошибок |
-| `npm run format` | Форматирование кода | Приведение к стандарту |
+## Commands that modify the checkout
 
-## 🧪 Тестирование
+| Command | Effect |
+| --- | --- |
+| `npm run codegen:all` | Rewrites generated GraphQL clients |
+| `npm run fix` | Applies Biome fixes and formatting |
+| `npm run format` | Applies Biome formatting |
+| `npm run clean` | Deletes generated build directories |
+| `npm run reset` | Cleans and reinstalls dependencies |
+| `npm run e2e:clean` | Deletes generated Playwright results |
 
-| Команда | Описание | Использование |
-|---------|----------|---------------|
-| `npm run e2e:install` | Установка Playwright браузеров | Первоначальная настройка |
-| `npm run e2e:tests` | Запуск E2E тестов | Полное тестирование |
-| `npm run e2e:debug` | Отладка тестов с UI | Разработка тестов |
-| `npm run e2e:headed` | Тесты с видимым браузером | Демонстрация |
+Review resulting diffs before committing them.
 
-## 🛠️ Дополнительные инструменты
+## Service-dependent testing
 
-| Команда | Описание | Использование |
-|---------|----------|---------------|
-| `npm run codegen` | Генерация GraphQL типов | После изменений схемы |
-| `npm run storybook` | Запуск Storybook | Разработка компонентов |
-| `npm run analyze` | Анализ бандла | Оптимизация размера |
-| `npm run templates` | Компиляция шаблонов | Обновление HTML шаблонов |
+`npm run e2e`, `npm run e2e:smoke`, `npm run e2e:auth`, and the `test:editor-*` scripts require compatible services; authenticated scenarios also require a dedicated test account. They should fail fast when prerequisites are missing and must never use personal or production credentials.
 
-## 🔧 Отладка
+Use `npm run e2e:demo` when a deterministic, account-free browser check is required.
 
-| Команда | Описание | Использование |
-|---------|----------|---------------|
-| `npm run dev:debug` | Разработка с отладчиком | Исследование проблем |
-| `npm run build:analyze` | Анализ сборки | Поиск узких мест |
-| `npm run check` | Полная проверка проекта | Перед PR |
+## Optional local setup
 
-## 📊 CI/CD команды
+- `npm run e2e:install` downloads Chromium for Playwright.
+- `npm run setup:https` uses `mkcert` and explicitly changes local certificate/trust configuration.
+- `npm run e2e:ui` and `npm run e2e:debug` open interactive Playwright tooling.
 
-| Команда | Описание | Использование |
-|---------|----------|---------------|
-| `npm run e2e:tests:ci` | Тесты для CI окружения | Автоматизированное тестирование |
-| `npm run build:netlify` | Сборка для Netlify | Альтернативный деплой |
-| `npm run test:coverage` | Покрытие кода тестами | Метрики качества |
-
-## 🔄 Рабочий процесс
-
-### Рекомендуемая последовательность
-```bash
-# Разработка
-npm run dev
-
-# Перед коммитом
-npm run typecheck
-npm run lint
-npm run fix
-
-# Тестирование
-npm run e2e:tests
-
-# Деплой
-npm run build
-```
-
-### Полная проверка
-```bash
-npm run check        # TypeScript + линтинг
-npm run e2e:tests    # E2E тесты
-npm run build        # Проверка сборки
-```
-
-## 🎯 Быстрые команды
-
-| Сценарий | Команды |
-|----------|---------|
-| **Начало работы** | `npm install && npm run dev` |
-| **Проверка кода** | `npm run check` |
-| **Исправление стиля** | `npm run fix` |
-| **Тестирование** | `npm run e2e:tests` |
-| **Сборка** | `npm run build` |
-
-## 📈 Оптимизации
-
-Команды используют современные инструменты для максимальной производительности:
-
-- **Lightning CSS** — сверхбыстрая обработка стилей
-- **Biome** — быстрый линтинг и форматирование
-- **Vite** — мгновенная пересборка при изменениях
-- **Playwright** — параллельное выполнение тестов
+No npm command in this repository publishes a release or deploys production by itself.


### PR DESCRIPTION
## Summary

- replace two stale npm command pages with references checked against `package.json`
- remove nonexistent preview, lint-fix, legacy E2E, Storybook, analyzer, coverage, and postinstall instructions
- distinguish deterministic demo checks from service-dependent and authenticated Playwright suites
- identify commands that modify files, install browsers, or change local certificate trust

## Validation

- 41 documented `npm run` commands matched to current scripts
- `npm run codegen:check` — passed
- `npm run check` — passed (11 unit tests)
- `npm run build` — passed
- `npm run e2e:demo` — passed (1 Chromium smoke)

Service-dependent and authenticated E2E commands were classified but not executed. No deployment or release command was run.

Closes #541