### PR TITLE
Run deterministic demo smoke in CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -56,3 +56,32 @@ jobs:
       - uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
+
+  demo-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies without lifecycle side effects
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Install the demo browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run deterministic demo smoke
+        run: npm run e2e:demo
+
+      - name: Upload demo failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-smoke-failure-${{ github.run_id }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary

- run the fixture-backed demo smoke as a separate CI job
- install only Chromium for the deterministic browser check
- retain Playwright failure artifacts for seven days and upload nothing on success

The demo stays loopback-only, read-only, and independent of account credentials or external services.

## Validation

- `npm run codegen:check`
- `npm run check` (11 tests)
- `npm run e2e:demo` (1 test)

Progresses #542.
