### PR TITLE
fix(a11y): require explicit header button types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -40,6 +40,18 @@
       "trailingCommas": "none"
     }
   },
+  "overrides": [
+    {
+      "includes": ["src/components/HeaderNav/HeaderControls.tsx"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "useButtonType": "error"
+          }
+        }
+      }
+    }
+  ],
   "linter": {
     "enabled": true,
     "includes": ["**", "!**/*.scss", "!**/*.md", "!**/.DS_Store", "!**/*.svg", "!**/*.d.ts"],

--- a/src/components/HeaderNav/HeaderControls.tsx
+++ b/src/components/HeaderNav/HeaderControls.tsx
@@ -110,7 +110,7 @@ const EditingHeader = (props: Props) => {
 
       {/* Кнопка поиска согласно дизайну */}
       <div class={clsx(styles.userControlItem, styles.userControlItemSearch)}>
-        <button class={styles.button} onClick={handleSearchClick} title={t('Search')}>
+        <button type="button" class={styles.button} onClick={handleSearchClick} title={t('Search')}>
           <Icon name="search" />
         </button>
       </div>
@@ -121,7 +121,7 @@ const EditingHeader = (props: Props) => {
           containerCssClass={styles.control}
           trigger={
             <div class={clsx(styles.userControlItem, styles.userControlItemUserpic)}>
-              <button class={styles.button}>
+              <button type="button" class={styles.button}>
                 <div classList={{ entered: Boolean(matchProfile()) }}>
                   <Userpic
                     size={'L'}
@@ -184,7 +184,7 @@ const AuthorizedHeader = (props: Props) => {
   return (
     <>
       <div class={clsx(styles.userControlItem, styles.userControlItemSearch)}>
-        <button class={styles.button} onClick={handleSearchClick} title={t('Search')}>
+        <button type="button" class={styles.button} onClick={handleSearchClick} title={t('Search')}>
           <Icon name="search" />
         </button>
       </div>
@@ -197,7 +197,7 @@ const AuthorizedHeader = (props: Props) => {
           containerCssClass={styles.control}
           trigger={
             <div class={clsx(styles.userControlItem, styles.userControlItemUserpic)}>
-              <button class={styles.button}>
+              <button type="button" class={styles.button}>
                 <div classList={{ entered: Boolean(matchProfile()) }}>
                   <Userpic
                     size={'L'}
@@ -229,7 +229,7 @@ const GuestHeader = () => {
   return (
     <>
       <div class={clsx(styles.userControlItem, styles.userControlItemSearch)}>
-        <button class={styles.button} onClick={handleSearchClick} title={t('Search')}>
+        <button type="button" class={styles.button} onClick={handleSearchClick} title={t('Search')}>
           <Icon name="search" />
         </button>
       </div>


### PR DESCRIPTION
## Summary

- add `type="button"` to the five search and profile controls in `HeaderControls`
- enable Biome `useButtonType` only for that component
- keep the broader accessibility rule set unchanged

## Validation

- the scoped rule covers the five current violations without suppressions
- CI runs lint, type-check, unit tests, runtime audit, build, and deterministic demo smoke

## Manual check before merge

- verify keyboard activation in guest, authenticated, and editing headers
- confirm the icon-only search and profile controls expose the expected accessible names

Implements the scoped code change proposed in #543; manual interaction checks remain required.