### PR TITLE
Fix lost mobile-menu clicks and strengthen contributor tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,20 @@ npm run check
 npm run build
 ```
 
-Playwright scenarios are optional unless your change affects their feature area. They require Chromium and, for authenticated tests, explicit test-only credentials:
+Unit tests need no services or credentials. Add a `*.test.mjs` file under `tests/unit/`; `npm test` discovers it automatically, including in subdirectories. The runner starts in `tests/unit/`, so resolve repository fixtures relative to `import.meta.url`, not the working directory. Playwright scenarios under `tests/e2e/` are not part of this command.
+
+For public shell or navigation changes, run the deterministic browser checks used in CI:
 
 ```bash
 npm run e2e:install
+npm run e2e:demo
+```
+
+This command starts and stops its own demo server. Leave ports 3000 and 4010 free; do not start `npm run dev:demo` separately. It requires no account, `.env` file, or live backend. The checks cover the public shell, navigation to the editorial guide, and opening and closing the mobile menu after deliberately delaying JavaScript. They do not verify authentication, publishing, or populated feeds.
+
+The historical integration suite remains separate. Run it only against compatible services you are authorised to use, with explicit test-only credentials for authenticated scenarios:
+
+```bash
 npm run e2e
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ To connect your own services, copy `.env.example` to `.env`, set the relevant pu
 | `npm run dev:demo` | Start the app with deterministic local fixture data |
 | `npm run dev` | Start against endpoints configured in `.env` |
 | `npm run check` | Lint, type-check, and run unit tests |
+| `npm test` | Run automatically discovered unit tests; no services or credentials needed |
 | `npm run codegen:check` | Verify committed GraphQL types match local schemas and operations |
 | `npm run build` | Create the production SSR build |
 | `npm run e2e:install` | Install the optional Playwright Chromium binary |
+| `npm run e2e:demo` | Check the public shell, guide navigation, and mobile menu against local fixtures |
 | `npm run e2e` | Run integration E2E tests against configured services |
 
 The generated GraphQL client is committed so a clean checkout can build offline. The local schemas in `src/graphql/schema/` are compatibility snapshots, not proof of a currently deployed API contract. See their provenance note before changing operations.
@@ -56,6 +58,7 @@ The generated GraphQL client is committed so a clean checkout can build offline.
 - `src/graphql/` — operations, local schema snapshots, and generated client types
 - `api/` and `.netlify/functions/` — feedback, newsletter, and media handlers
 - `tests/e2e/` — service-dependent Playwright scenarios
+- `tests/demo-e2e/` — account-free browser checks using local fixtures
 - `tests/unit/` — deterministic Node tests used in CI
 
 The stack is SolidJS/SolidStart, TypeScript, Vinxi/Vite, URQL/GraphQL Code Generator, SCSS/Lightning CSS, Biome, and Playwright.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "e2e:ci": "cross-env CI=true npm run e2e:test",
     "e2e:install": "playwright install chromium",
     "test": "npm run test:unit",
-    "test:unit": "node --test tests/unit/static-files.test.mjs tests/unit/request-validation.test.mjs tests/unit/demo-api.test.mjs tests/unit/image-runtime.test.mjs tests/unit/runtime-auth-logging.test.mjs",
+    "test:unit": "cd tests/unit && node --test",
     "build:ci": "cross-env SASS_FORCE_JS=true npm run build",
     "templates": "node ./templates/compile.cjs",
     "setup:https": "node scripts/setup-https.mjs",

--- a/src/components/HeaderNav/Header.tsx
+++ b/src/components/HeaderNav/Header.tsx
@@ -47,6 +47,7 @@ export const Header = (props: Props) => {
   const [getIsScrollingBottom, setIsScrollingBottom] = createSignal(false)
   const [getIsScrolled, setIsScrolled] = createSignal(false)
   const [fixed, setFixed] = createSignal(false)
+  const [isMenuReady, setIsMenuReady] = createSignal(false)
   const [isSharePopupVisible, setIsSharePopupVisible] = createSignal(false)
   const [isProfilePopupVisible, setIsProfilePopupVisible] = createSignal(false)
 
@@ -81,6 +82,7 @@ export const Header = (props: Props) => {
   })
 
   onMount(() => {
+    setIsMenuReady(true)
     let scrollTop = window.scrollY
 
     const handleScroll = () => {
@@ -179,6 +181,7 @@ export const Header = (props: Props) => {
                 aria-label={fixed() ? 'Закрыть меню' : 'Открыть меню'}
                 aria-expanded={fixed()}
                 aria-controls="main-navigation"
+                disabled={!isMenuReady()}
                 type="button"
               >
                 <div />

--- a/tests/demo-e2e/smoke.spec.ts
+++ b/tests/demo-e2e/smoke.spec.ts
@@ -2,7 +2,54 @@ import { expect, test } from '@playwright/test'
 
 test('renders the public application shell with local fixture data', async ({ page }) => {
   const response = await page.goto('/')
-  expect(response?.status()).toBeLessThan(400)
-  await expect(page.locator('body')).toBeVisible()
+  expect(response?.status()).toBe(200)
+  const navigation = page.getByRole('navigation', { name: 'Основная навигация', exact: true })
+  await expect(navigation).toBeVisible()
+  await expect(navigation.getByRole('link', { name: 'Перейти на главную страницу Discours' })).toBeVisible()
+  await expect(navigation.locator('#main-navigation a[href="/"]')).toHaveAttribute('aria-current', 'page')
   await expect(page.locator('body')).not.toContainText('Internal Server Error')
+})
+
+test('opens the editorial guide from the public navigation', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.locator('button[aria-controls="main-navigation"]')).toBeEnabled()
+  await page.locator('#main-navigation a[href="/guide"]').click()
+
+  await expect(page).toHaveURL(/\/guide$/)
+  await expect(page.getByRole('heading', { level: 1, name: 'How Discours works', exact: true })).toBeVisible()
+  await expect(page.locator('#articleBody #how-it-works')).toBeVisible()
+  await expect(page.locator('#main-navigation a[href="/guide"]')).toHaveAttribute('aria-current', 'page')
+})
+
+test('opens and closes the mobile menu after hydration', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  let releaseScripts: () => void = () => {}
+  const scriptsReady = new Promise<void>((resolve) => {
+    releaseScripts = resolve
+  })
+  await page.route('**/*', async (route) => {
+    if (route.request().resourceType() === 'script') await scriptsReady
+    await route.continue()
+  })
+
+  const menu = page.getByRole('button', { name: 'Открыть меню', exact: true })
+  try {
+    // Hold scripts until we have checked the server-rendered control.
+    await page.goto('/', { waitUntil: 'commit' })
+    await expect(menu).toBeVisible()
+    await expect(menu).toBeDisabled()
+  } finally {
+    releaseScripts()
+  }
+
+  // Playwright must wait for the real control to become usable, not a timer.
+  await expect(menu).toHaveAttribute('aria-expanded', 'false')
+  await menu.click()
+
+  const closeMenu = page.getByRole('button', { name: 'Закрыть меню', exact: true })
+  await expect(closeMenu).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.locator('#main-navigation a[href="/guide"]')).toBeVisible()
+  await closeMenu.click()
+  await expect(menu).toHaveAttribute('aria-expanded', 'false')
+  await expect(page.locator('#main-navigation a[href="/guide"]')).toBeHidden()
 })


### PR DESCRIPTION
## Summary

- Keep the mobile menu button disabled until its client-side handler is mounted. A fast click previously arrived before hydration and did nothing.
- Strengthen demo smoke assertions and cover guide navigation plus a delayed-JavaScript mobile menu interaction.
- Automatically discover unit tests under `tests/unit/`, including nested additions, without including service-dependent Playwright specs.
- Document the account-free browser checks and their limits in README and CONTRIBUTING.

Related to #542. This does not close the remaining integration-suite classification and prerequisite checks.

## Validation

- `npm run codegen:check` passed without generated-client changes.
- `npm run check` passed: lint, TypeScript, and 11 unit tests.
- `npm run e2e:demo` passed all 3 browser scenarios using local fixtures and no account credentials.
- Negative control: adding a deliberately failing nested unit test made `npm test` fail. The temporary test was then removed.
- Before the fix, the mobile-menu click failed in two runs. The isolated trace places the click about 0.7 seconds before the header mounted. The new test holds JavaScript requests until it verifies the server-rendered button is disabled, then releases them and checks opening and closing.
- `npm run build` passed, including Nitro server packaging.
- [GitHub CI](https://github.com/discours/discoursio-webapp/actions/runs/34624146578) passed all three jobs (`quality`, `demo-smoke`, `dependency-review`) on `ff6833f4156490ed363f60a2655a033462f60764`.

## Scope

No dependency, deployment, backend-contract, or authentication changes. The mobile-menu fix is limited to three lines in `Header.tsx`; it does not modify `HeaderControls.tsx` or overlap the scoped changes in #549. This PR does not verify live services, authentication, publishing, or populated feeds.
